### PR TITLE
Icon Suffix property spelling incorrect.

### DIFF
--- a/Entities/Icon.cs
+++ b/Entities/Icon.cs
@@ -15,7 +15,7 @@ namespace FourSquare.SharpSquare.Entities
         /// <summary>
         /// Suffix of the image, example .png .ico etc
         /// </summary> 
-        public string sufix { get; set; }
+        public string suffix { get; set; }
 
     }
 }


### PR DESCRIPTION
Change from sufix to suffix.  Was null, now populating correctly with the avatar filename.
